### PR TITLE
Add color utilities

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -158,6 +158,44 @@ module.exports = {
         secondary: 'var(--app-brand-secondary, #f36f20)', // orange
       },
 
+      'ui-blue': {
+        1: 'var(--calcite-ui-blue-1)',
+        2: 'var(--calcite-ui-blue-2)',
+        3: 'var(--calcite-ui-blue-3)',
+      },
+      'ui-green': {
+        1: 'var(--calcite-ui-green-1)',
+        2: 'var(--calcite-ui-green-2)',
+        3: 'var(--calcite-ui-green-3)',
+      },
+      'ui-red': {
+        1: 'var(--calcite-ui-red-1)',
+        2: 'var(--calcite-ui-red-2)',
+        3: 'var(--calcite-ui-red-3)',
+      },
+      'ui-yellow': {
+        1: 'var(--calcite-ui-yellow-1)',
+        2: 'var(--calcite-ui-yellow-2)',
+        3: 'var(--calcite-ui-yellow-3)',
+      },
+      'ui-background': 'var(--calcite-ui-background)',
+      'ui-border': {
+        1: 'var(--calcite-ui-border-1)',
+        2: 'var(--calcite-ui-border-2)',
+        3: 'var(--calcite-ui-border-3)',
+        4: 'var(--calcite-ui-border-4)',
+        5: 'var(--calcite-ui-border-5)',
+      },
+      'ui-foreground': {
+        1: 'var(--calcite-ui-foreground-1)',
+        2: 'var(--calcite-ui-foreground-2)',
+        3: 'var(--calcite-ui-foreground-3)',
+      },
+      'ui-text': {
+        1: 'var(--calcite-ui-text-1)',
+        2: 'var(--calcite-ui-text-2)',
+        3: 'var(--calcite-ui-text-3)',
+      },
     },
 
     screens: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,10 +7,27 @@ module.exports = {
     colors: {
       // Basic colors
       blue: {
+        h: {
+          60: colors['h-bb-060'],
+          70: colors['h-bb-070'],
+        },
         m: {
           50: colors['m-bb-050']
+        },
+        d: {
+          420: colors['d-bb-420']
         }
-      }
+      },
+
+      red: {
+        h: {
+          60: colors['h-rr-060'],
+          70: colors['h-rr-070']
+        },
+        d: {
+          420: colors['d-rr-420']
+        }
+      },
 
       // Functional colors
       'ui-blue': {
@@ -168,6 +185,7 @@ module.exports = {
     position: [ 'responsive', 'rtl' ],
     stroke: [],
     textAlign: [ 'responsive', 'rtl', 'mirror' ],
+    textColor: [ 'responsive', 'dark', 'hover', 'focus' ],
   },
 
   corePlugins: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -185,7 +185,7 @@ module.exports = {
     position: [ 'responsive', 'rtl' ],
     stroke: [],
     textAlign: [ 'responsive', 'rtl', 'mirror' ],
-    textColor: [ 'responsive', 'dark', 'hover', 'focus' ],
+    textColor: [ 'responsive', 'hover', 'focus' ],
   },
 
   corePlugins: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,184 +1,44 @@
+const colors = require("@esri/calcite-colors/colors.json")
+
 module.exports = {
 
   theme: {
 
     colors: {
-
-      yellow: {
-        lightest: '#faf7dc', // m-yy-010
-        lighter: '#f6f0c1',  // m-yy-020
-        light: '#fcee8d',    // h-yy-030
-        default: '#edd317',  // h-yy-060
-        dark: '#d9bc00',     // h-yy-070
-        darker: '#8c7500',   // h-yy-090
-        darkest: '#5c4e00',  // h-yy-100
-      },
-
-      'yellow-green': {
-        lightest: '#f0f7da', // m-yg-010
-        lighter: '#e5efc6',  // m-yg-020
-        light: '#cde78a',    // h-yg-030
-        default: '#aad04b',  // h-yg-060
-        dark: '#84a338',     // h-yg-070
-        darker: '#384813',   // h-yg-090
-        darkest: '#121a00',  // h-yg-100
-      },
-
-      green: {
-        lightest: '#e4f0e4', // m-gg-010
-        lighter: '#cbe2cb',  // m-gg-020
-        light: '#87d692',    // h-gg-030
-        default: '#35ac46',  // h-gg-060
-        dark: '#288835',     // h-gg-070
-        darker: '#0d3f14',   // h-gg-090
-        darkest: '#001a03',  // h-gg-100
-      },
-
-      'green-blue': {
-       lightest: '#dbf2f1', // m-gb-010
-        lighter: '#beedec',  // m-gb-020
-        light: '#8fe6e5',    // h-gb-030
-        default: '#00bab5',  // h-gb-060
-        dark: '#009b98',     // h-gb-070
-        darker: '#004d4c',   // h-gb-090
-        darkest: '#002625',  // h-gb-100
-      },
-
+      // Basic colors
       blue: {
-        lightest: '#dfeffa', // m-bb-010
-        lighter: '#c8e3f5',  // m-bb-020
-        light: '#77bde7',    // h-bb-030
-        default: '#007ac2',  // h-bb-060
-        dark: '#00619b',     // h-bb-070
-        darker: '#00304d',   // h-bb-090
-        darkest: '#001726',  // h-bb-100
-      },
-
-      violet: {
-        lightest: '#ece6ff', // m-vv-010
-        lighter: '#dcd2f2',  // m-vv-020
-        light: '#b39ad7',    // h-vv-030
-        default: '#633b9b',  // h-vv-060
-        dark: '#4e2c7e',     // h-vv-070
-        darker: '#250f43',   // h-vv-090
-        darkest: '#100026',  // h-vv-100
-      },
-
-      'violet-red': {
-        lightest: '#f6e1fa', // m-vr-010
-        lighter: '#e9ceee',  // m-vr-020
-        light: '#cfa1d7',    // h-vr-030
-        default: '#8e499b',  // h-vr-060
-        dark: '#73377e',     // h-vr-070
-        darker: '#3c1243',   // h-vr-090
-        darkest: '#200026',  // h-vr-100
-      },
-
-      pink: {
-        lightest: '#fadef0', // m-pk-010
-        lighter: '#facdea',  // m-pk-020
-        light: '#f2a5d6',    // h-pk-030
-        default: '#e04ea6',  // h-pk-060
-        dark: '#ba2f7e',     // h-pk-070
-        darker: '#590b32',   // h-pk-090
-        darkest: '#260404',  // h-pk-100
-      },
-
-      red: {
-        lightest: '#fadfdc', // m-rr-010
-        lighter: '#fccac5',  // m-rr-020
-        light: '#f2877b',    // h-rr-030
-        default: '#d83020',  // h-rr-060
-        dark: '#a82b1e',     // h-rr-070
-        darker: '#4f0e08',   // h-rr-090
-        darkest: '#210300',  // h-rr-100
-      },
-
-      'red-orange': {
-        lightest: '#f7e4dc', // m-ro-010
-        lighter: '#f5d0c2',  // m-ro-020
-        light: '#f09677',    // h-ro-030
-        default: '#da4d1e',  // h-ro-060
-        dark: '#ad3c16',     // h-ro-070
-        darker: '#531b07',   // h-ro-090
-        darkest: '#260a00',  // h-ro-100
-      },
-
-      orange: {
-        lightest: '#ffece0', // m-oo-010
-        lighter: '#fcdac5',  // m-oo-020
-        light: '#faae7f',    // h-oo-030
-        default: '#f36f20',  // h-oo-060
-        dark: '#c65a18',     // h-oo-070
-        darker: '#6d2f08',   // h-oo-090
-        darkest: '#401900',  // h-oo-100
-      },
-
-      'orange-yellow': {
-        lightest: '#ffedd6', // m-oy-010
-        lighter: '#fce0bd',  // m-oy-020
-        light: '#fcc582',    // h-oy-030
-        default: '#f89927',  // h-oy-060
-        dark: '#c67718',     // h-oy-070
-        darker: '#6d3f08',   // h-oy-090
-        darkest: '#402300',  // h-oy-100
-      },
-
-      // Grayscale
-      'white': 'white',
-
-      gray: {
-        lightest: '#f8f8f8', // blk-005
-        lighter: '#dfdfdf',  // blk-030
-        light: '#bfbfbf',    // blk-060
-        default: '#9f9f9f',  // blk-090
-        dark: '#606060',     // blk-150
-        darker: '#404040',   // blk-180
-        darkest: '#2b2b2b',  // blk-200
-      },
-
-      black: '#151515', // blk-220
-
-      transparent: 'transparent',
+        m: {
+          50: colors['m-bb-050']
+        }
+      }
 
       // Functional colors
-      alert: {
-        red: '#d83020',
-        yellow: '#edd317',
-        green: '#35ac46',
-        blue: '#007ac2',
-      },
-
-      // Brand colors (Theme)
-      brand: {
-        light: 'var(--app-brand-primary-light, #c8e3f5)', // blue-lighter
-        default: 'var(--app-brand-primary, #007ac2)', // blue
-        dark: 'var(--app-brand-primary-dark, #00304d)', // blue-darker
-        highlight: 'var(--app-brand-primary-highlight, #77bde7)', // blue-light
-        secondary: 'var(--app-brand-secondary, #f36f20)', // orange
-      },
-
       'ui-blue': {
         1: 'var(--calcite-ui-blue-1)',
         2: 'var(--calcite-ui-blue-2)',
         3: 'var(--calcite-ui-blue-3)',
       },
+
       'ui-green': {
         1: 'var(--calcite-ui-green-1)',
         2: 'var(--calcite-ui-green-2)',
         3: 'var(--calcite-ui-green-3)',
       },
+
       'ui-red': {
         1: 'var(--calcite-ui-red-1)',
         2: 'var(--calcite-ui-red-2)',
         3: 'var(--calcite-ui-red-3)',
       },
+
       'ui-yellow': {
         1: 'var(--calcite-ui-yellow-1)',
         2: 'var(--calcite-ui-yellow-2)',
         3: 'var(--calcite-ui-yellow-3)',
       },
+
       'ui-background': 'var(--calcite-ui-background)',
+
       'ui-border': {
         1: 'var(--calcite-ui-border-1)',
         2: 'var(--calcite-ui-border-2)',
@@ -186,16 +46,40 @@ module.exports = {
         4: 'var(--calcite-ui-border-4)',
         5: 'var(--calcite-ui-border-5)',
       },
+
       'ui-foreground': {
         1: 'var(--calcite-ui-foreground-1)',
         2: 'var(--calcite-ui-foreground-2)',
         3: 'var(--calcite-ui-foreground-3)',
       },
+
       'ui-text': {
         1: 'var(--calcite-ui-text-1)',
         2: 'var(--calcite-ui-text-2)',
         3: 'var(--calcite-ui-text-3)',
       },
+
+      // Grayscale
+      white: colors['blk-000'],
+
+      black: colors['blk-240'],
+
+      transparent: 'transparent',
+
+      gray: {
+        5: colors['blk-015'],
+        10: colors['blk-010'],
+        20: colors['blk-020'],
+        40: colors['blk-040'],
+        80: colors['blk-080'],
+        120: colors['blk-120'],
+        170: colors['blk-170'],
+        180: colors['blk-180'],
+        190: colors['blk-190'],
+        200: colors['blk-200'],
+        220: colors['blk-220'],
+        230: colors['blk-230'],
+      }
     },
 
     screens: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -185,7 +185,6 @@ module.exports = {
     position: [ 'responsive', 'rtl' ],
     stroke: [],
     textAlign: [ 'responsive', 'rtl', 'mirror' ],
-    textColor: [ 'responsive', 'hover', 'focus' ],
   },
 
   corePlugins: {


### PR DESCRIPTION
I added color utilities for all the colors I saw in the calcite-component repo.  Most of them refer to the `ui-` color variables that have built-in light / dark variants.  The rest are grayscale values, and a few straggler colors I found scattered in the component styling.